### PR TITLE
Lg

### DIFF
--- a/gres_gpu.c
+++ b/gres_gpu.c
@@ -152,7 +152,11 @@ static void _set_ve_env_vars(char ***env_ptr, char *local_list)
 		for (int i = 0; i < local_id; i++) {
 			while (*local_ve && isdigit(*local_ve))
 				local_ve++;
-			local_ve++;
+			if (!*local_ve) {
+				local_ve = q;
+			} else {
+				local_ve++;
+			}
 		}
 		// VE_NODE_NUMBER set to local_id'th VE in the list.
 		p = local_ve;

--- a/scripts/taskprolog.sh
+++ b/scripts/taskprolog.sh
@@ -2,6 +2,8 @@
 if [ -n "$_VENODELIST" ]; then
     declare -a VE_NODE_IDS
     VE_NODE_IDS=($_VENODELIST)
-    echo "export VE_NODE_NUMBER=${VE_NODE_IDS[$SLURM_LOCALID]}"
+    NB_VE=${#VE_NODE_IDS[@]}
+    LOCALID=$(( ${SLURM_LOCALID} % ${NB_VE} ))
+    [ -z "${SLURMD_TRES_BIND}" ] && echo "export VE_NODE_NUMBER=${VE_NODE_IDS[$LOCALID]}"
     echo "export _NECMPI_VH_NODENUM=${SLURM_NODEID}"
 fi


### PR DESCRIPTION
Hi Erich,

those patches do 3 things:
1) plugin will always set a value to VE_NODE_NUMBER, by default it will set it to first VE in the list. I think this is important to always have VE_NODE_NUMBER set, so this will work if TaskProlog is not set.

2) VE_NODE_NUMBER is set in round robin manner (in the plugin and in the script): this allow to do srun with more tasks than VE. For example you do offload, and use 1 VE core per task.

3) TaskProlog script set VE_NODE_NUMBER only if user did not request for specific binding (--gpu-bind option) 

Regards,
   Laurent.